### PR TITLE
Add peer dep for html-webpack-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Version requirements:
 
 - Node.js: `v8.12.0`
 - Webpack: `v4.0.0`
-- [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin): `v4.0.0`
+- [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin): `v4.3.0`
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2"
+  },
+  "peerDependencies": {
+    "html-webpack-plugin": "^4.3.0"
   }
 }


### PR DESCRIPTION
[Seems like this plugin will not work](https://github.com/jantimon/html-webpack-plugin/issues/1091#issuecomment-626368958) when using npm, unless it is defined under `peerDependencies`, works fine with yarn though.

