### PR TITLE
feat: add `allowedHosts` option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,12 @@ import HtmlWebpackPlugin from 'html-webpack-plugin'
 
 class EsiWebpackPlugin {
   constructor(options = {}) {
-    const { baseUrl, onError, processOptions = {} } = options
+    const { allowedHosts, baseUrl, onError, processOptions = {} } = options
 
     this.options = options
 
     this.esi = new ESI({
+      allowedHosts,
       baseUrl,
       onError,
       processOptions,


### PR DESCRIPTION
Make allowed host a valid option to pass to the new ESI, since nodesi accepts it.